### PR TITLE
Update rust depencencies and py03 related changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruranges"
-version = "0.1.0"
+version = "0.0.15"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,11 +10,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 radsort = "0.1.1"
-rustc-hash = "2.1.0"
+rustc-hash = "2.1.1"
 num-traits = "0.2.19"
 
-pyo3 = { version = "0.26.0", features = ["extension-module"], optional = false }
-numpy = { version = "0.26.0", optional = false }
+pyo3 = { version = "0.27.2", features = ["extension-module", "abi3-py310"], optional = false }
+numpy = { version = "0.27.1", optional = false }
 
 # polars = { version = "0.46.0", features = ["csv", "lazy", "dtype-categorical"], optional = false}
 # rust-htslib = { version = "0.49.0", optional = false}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-version = "0.0.15"
+dynamic = ["version"]
 
 [tool.maturin]
 module-name = "ruranges"


### PR DESCRIPTION
Update rust depencencies and py03 related changes.
  - Update pyo3 and rust_numpy to support python 3.14.
  - Build extension with abi3 support:
      - Only one wheel needs to be build per OS/architecture combination and will work with all python version. "abi-py310" ==> python 3.10 or higher.
      - https://pyo3.rs/v0.27.2/building-and-distribution.html#py_limited_apiabi3
  - Specify version number in Cargo.toml