### PR TITLE
Document the index and count contracts, release 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruranges-py"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,7 +18,7 @@ python-module = ["pyo3/extension-module"]
 
 [dependencies]
 # Core interval algorithms now live in the separate Rust crate/repo.
-ruranges-core = { version = "0.1.5" }
+ruranges-core = { version = "0.1.9" }
 
 # Python bindings.
 rustc-hash = "2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.maturin]
 module-name = "ruranges.ruranges"

--- a/ruranges/numpy.py
+++ b/ruranges/numpy.py
@@ -582,8 +582,11 @@ def complement(
     Returns
     -------
     out_chrs, out_starts, out_ends, out_idx
-        `out_idx` holds the 0-based index of the input interval immediately
-        **following** each gap (useful for attribution).
+        `out_chrs` holds the group each gap belongs to and is the reliable key
+        for attribution.  `out_idx` holds the 0-based index of *one* input
+        interval belonging to that group; it identifies the group, not a
+        particular member, so callers must not depend on which member is
+        reported.  Prefer `out_chrs` when mapping gaps back to per-group values.
 
     Notes
     -----
@@ -613,12 +616,11 @@ def boundary(
     NDArray[GroupIdInt],  # counts
 ]:
     """
-    Collapse adjacent/overlapping intervals into *boundary segments*.
+    Collapse each group's intervals into its outer boundary.
 
-    Each boundary represents a contiguous genomic stretch where at least one
-    interval is present.  Returns the permutation (indices) of the *first*
-    interval contributing to each boundary and how many intervals overlapped
-    the segment (*counts*).
+    Returns one row per group, spanning that group's minimum start to its
+    maximum end.  Gaps inside a group do not split the result: a group always
+    yields exactly one row.
 
     Parameters
     ----------
@@ -631,6 +633,11 @@ def boundary(
     Returns
     -------
     indices, boundary_starts, boundary_ends, counts
+        ``indices`` holds the position of *one* input interval belonging to each
+        group.  It identifies the group, not a particular member, so callers
+        must not depend on which member is reported; use it only to read values
+        that are constant across the group, such as grouping columns.
+        ``counts`` holds the number of input intervals in each group.
         All arrays are `uint32` for IDs/counts and ``RangeInt`` for
         coordinates, matching the rest of the API.
     """


### PR DESCRIPTION
## Summary

Corrects two docstrings that promised guarantees the kernels do not provide, and releases the corrected kernels as `ruranges` 0.1.5 so downstreams can require the fix.

Depends on pyranges/ruranges-core#1 — merge and publish `ruranges-core` 0.1.9 first.

### The docstrings were wrong

Both functions documented their index as identifying a *specific* interval:

* `boundary` — "the permutation (indices) of the **first** interval contributing to each boundary"
* `complement` — "the 0-based index of the input interval immediately **following** each gap (useful for attribution)"

Neither holds. The index only identifies the **group**. `pyranges1` took the `complement` wording at face value and used the index to recover grouping columns, which silently mislabelled `Chromosome` and `Strand` (pyranges/pyranges1#157).

`boundary` also described itself as splitting input into contiguous segments and reporting overlap counts. It returns exactly **one row per group**, spanning that group's minimum start to maximum end; gaps inside a group do not split the result. `counts` holds the number of intervals in the group.

Both docstrings now state what callers can rely on, and `complement` points at `out_chrs` — the dependable attribution key, which callers were previously ignoring in favour of the unreliable index.

## Compatibility

No signature or arity changes: `boundary` still returns four arrays, `complement` four. Existing code keeps working unchanged and simply receives correct values once the new core is in place.

## Versions

* `ruranges-core` dependency: `0.1.5` → `0.1.9` (the release carrying the fixes)
* crate `ruranges-py`: 0.2.2 → 0.2.3
* Python distribution `ruranges`: 0.1.4 → **0.1.5**

The distribution bump matters: pyranges/pyranges1 raises its floor to `ruranges>=0.1.5` to guarantee it never runs against a mis-attributing kernel, so that release number is what downstreams pin to.

## Tests

Docs and version metadata only — no logic changes here, so the correctness tests live in ruranges-core (pyranges/ruranges-core#1, 20 passing).

Verified by building this branch against the fixed core and exercising the wheel in a clean virtualenv:

* `maturin build --release` succeeds; wheel reports version **0.1.5**.
* `boundary(...)` returns **4 arrays**, with `counts == [2, 2]` for two groups of two intervals (previously `[0, 4]`).
* `complement(...)` returns an index that lands in the gap's own group (previously row 0, a foreign group).
* Installed alongside an **unmodified** `pyranges1`: 65/65 unit tests, 10/10 tutorial/how-to doctests, 79/80 module doctests — the single failure is `to_bigwig`, which needs the optional `pyrle` package that was not installed, and fails identically before these changes.
