### PR TITLE
Require ruranges-core 0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruranges-py"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,7 +18,7 @@ python-module = ["pyo3/extension-module"]
 
 [dependencies]
 # Core interval algorithms now live in the separate Rust crate/repo.
-ruranges-core = { version = "0.1.9" }
+ruranges-core = { version = "0.1.11" }
 
 # Python bindings.
 rustc-hash = "2.1.0"


### PR DESCRIPTION
Raises the core requirement so this wheel picks up two ruranges-core changes.

**Depends on pyranges/ruranges-core#4 being merged and 0.1.11 published.** CI will not resolve until then.

## What this propagates

- **0.1.9 — contained overlaps with negative slack.** The sweep leaked state, so a query could report a hit its contracted interval no longer supports. This is the release that carries that correction to pyranges1. It changes results for `contained_intervals_only=True` combined with a negative slack; niche, but real.
- **0.1.11 — projection reports the emitting annotation row.** Not used by this crate's bindings, which compile unchanged.

## Verification

Built against ruranges-core 0.1.11 from a path patch: 0 errors, no source changes needed. Version bumped 0.2.3 → 0.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
