### PR TITLE
Bump the wheel version to 0.1.6 so publishing succeeds

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -46,4 +46,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages: "dist/*.whl dist/*.tar.gz"
+          packages-dir: dist
+          skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.maturin]
 module-name = "ruranges.ruranges"


### PR DESCRIPTION
The wheel publish failed with `400 File already exists ('ruranges-0.1.5-...whl')`.

## Cause — mine

In #35 I bumped `Cargo.toml` from 0.2.3 to 0.2.4. That is the **Cargo package `ruranges-py`**, which is not what maturin names the distribution. The wheel version comes from `pyproject.toml`'s `[project] version`, which was still `0.1.5` — already on PyPI. Every file was therefore a duplicate.

The two version numbers are unrelated and already far apart (Cargo 0.2.x, PyPI 0.1.x), which is what I missed.

- `pyproject.toml`: `0.1.5` → **`0.1.6`**

## Two publish-step fixes while here

The run also logged:

> Unexpected input(s) 'packages', valid inputs are ['user', 'password', … 'packages-dir', …]

`packages` is not an input of `gh-action-pypi-publish`; it was silently ignored and the action fell back to its `dist/` default, which happened to be correct. Renamed to `packages-dir`.

Added `skip-existing: true` so a re-run after a partial upload finishes the remaining files rather than failing the job on the first duplicate — which is exactly the state this run left things in.

## Note

Wheels and sdist built fine; only the upload failed. Nothing needs rebuilding, and no released artifact is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
