### PR TITLE
Expose the ranks kernels, and make sort_intervals' groups keyword-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,3 @@ ruranges-core = { version = "0.1.12" }
 rustc-hash = "2.1.0"
 pyo3 = { version = "0.26.0", optional = false }
 numpy = { version = "0.26.0", optional = true }
-
-# Development override: `ranks` (natural/lexical ranking, shared with polaranges)
-# lands in ruranges-core 0.1.12. Drop this patch once 0.1.12 is on crates.io.
-[patch.crates-io]
-ruranges-core = { path = "../ruranges-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruranges-py"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,9 +18,14 @@ python-module = ["pyo3/extension-module"]
 
 [dependencies]
 # Core interval algorithms now live in the separate Rust crate/repo.
-ruranges-core = { version = "0.1.11" }
+ruranges-core = { version = "0.1.12" }
 
 # Python bindings.
 rustc-hash = "2.1.0"
 pyo3 = { version = "0.26.0", optional = false }
 numpy = { version = "0.26.0", optional = true }
+
+# Development override: `ranks` (natural/lexical ranking, shared with polaranges)
+# lands in ruranges-core 0.1.12. Drop this patch once 0.1.12 is on crates.io.
+[patch.crates-io]
+ruranges-core = { path = "../ruranges-core" }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ python -c "import ruranges; print(ruranges.__version__)"
 | Set algebra           | subtract                                   | A minus B                                       |
 |                       | complement                                 | gaps within chromosome bounds                   |
 |                       | merge, cluster, max\_disjoint              | collapse or filter overlaps                     |
-| Utility               | sort\_intervals, window, tile, extend, ... | assorted helpers                                |
+| Sorting               | sort\_intervals                            | row order for a (group, start, end) sort        |
+|                       | natural\_rank, lexical\_rank               | order a key column's distinct string values     |
+|                       | fold\_ranks                                | collapse several coded keys into one group id   |
+| Utility               | window, tile, extend, ...                  | assorted helpers                                |
 
 Below are the three most common calls: overlaps, nearest, subtract.
 
@@ -190,6 +193,51 @@ print(sub_ends)
 ```
 
 Because interval 1 is broken into two pieces it appears twice in idx\_keep.
+
+---
+
+## 4. Sorting by string keys
+
+`sort_intervals` sorts by `(group, start, end)`, where `group` is an integer. To
+sort by *string* keys — chromosome names, transcript ids — code each key column
+first, then fold the codes into one group id:
+
+```python
+import numpy as np
+import pandas as pd
+import ruranges
+
+chromosome = pd.array(["chr10", "chr2", "chr2", "chr10"], dtype="str")
+start = np.array([100, 300, 100, 300], dtype=np.int32)
+end = np.array([150, 350, 150, 350], dtype=np.int32)
+
+# 1. Code the key column: factorize the rows, rank the *distinct* values.
+codes, uniques = pd.factorize(chromosome, sort=False)
+rank = ruranges.numpy.natural_rank(uniques)
+group = rank[codes].astype(np.uint32)
+
+# 2. One kernel call, one gather.
+order = ruranges.numpy.sort_intervals(start, end, groups=group)
+print(chromosome[order])
+# ['chr2', 'chr2', 'chr10', 'chr10']
+```
+
+Natural order puts `chr2` before `chr10`; swap in `lexical_rank` for plain byte
+order. Ranking the distinct values rather than the rows is what makes this
+affordable — the cost is per distinct value, so 25 chromosome names cost
+nothing regardless of row count.
+
+With more than one key column, fold each column's codes into the running group
+id before the kernel call:
+
+```python
+group, cardinality = ruranges.numpy.fold_ranks(
+    group, len(uniques), strand_codes, 2
+)
+```
+
+`fold_ranks` handles the `uint32` overflow that a plain
+`group * cardinality + codes` would hit once the keys are wide enough.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.maturin]
 module-name = "ruranges.ruranges"

--- a/ruranges/numpy.py
+++ b/ruranges/numpy.py
@@ -362,6 +362,7 @@ def count_overlaps(
 def sort_intervals(
     starts: NDArray[RangeInt],
     ends: NDArray[RangeInt],
+    *,
     groups: NDArray[GroupIdInt] | None = None,
     sort_reverse_direction: NDArray[np.bool_] | None = None,
 ) -> NDArray[GroupIdInt]:
@@ -376,7 +377,10 @@ def sort_intervals(
     groups
         Optional per-row group IDs (chromosomes, contigs, …).  If supplied, the
         sort is performed *within* each group; otherwise intervals are sorted
-        globally.
+        globally.  **Keyword-only**: all three arrays are same-length integer
+        arrays, so passing them in the wrong order is otherwise undetectable —
+        which is exactly how ``pyranges1`` came to sort by ``End`` before
+        ``Start`` for two releases.
     sort_reverse_direction
         Optional boolean array (same length as *starts*) marking rows that
         should be ordered **descendingly** within their group/position tier.
@@ -399,6 +403,131 @@ def sort_intervals(
         ends=ends,
         sort_reverse_direction=sort_reverse_direction,
     )
+
+
+def natural_rank(values: Sequence[str]) -> NDArray[np.uint32]:
+    """
+    Return the position each value would occupy in natural order.
+
+    Natural order reads a string as alternating text and number runs: text runs
+    compare as text, number runs compare as numbers.  So ``t2`` sorts before
+    ``t10``, and ``chr9 < chr10 < chrM``.
+
+    This is the ordering ``sort_ranges`` applies to string keys when
+    ``natsort=True``, and it is defined once — here — so that every library
+    built on ruranges answers the same way.  It reproduces Python's
+    ``natsort.natsorted`` under default settings except that it does not
+    Unicode-normalise, so strings differing only in composed non-ASCII
+    characters may order differently; see ``ruranges_core::ranks``.
+
+    Parameters
+    ----------
+    values
+        The **distinct** values of a key column, e.g. the ``uniques`` returned
+        by :func:`pandas.factorize`.  Ranking distinct values rather than rows
+        is what makes natural ordering affordable: the cost is per distinct
+        value, not per row.
+
+    Returns
+    -------
+    ranks : NDArray[np.uint32]
+        ``ranks[i]`` is the sorted position of ``values[i]``.  Every element
+        gets its own rank; values that compare equal (``t1`` and ``t01`` do,
+        since leading zeros vanish in a number) keep their input order.
+
+    Examples
+    --------
+    >>> natural_rank(["chr10", "chr2", "chrX", "chr1"])
+    array([2, 1, 3, 0], dtype=uint32)
+    """
+    rust_mod = importlib.import_module(".ruranges", package="ruranges")
+    return rust_mod.natural_rank_numpy(list(values))
+
+
+def lexical_rank(values: Sequence[str]) -> NDArray[np.uint32]:
+    """
+    Return the position each value would occupy in byte-lexical order.
+
+    The counterpart to :func:`natural_rank` for ``natsort=False`` and for
+    generic (non-genomic) frames, which have no chromosome column and so no
+    reason to order strings naturally.  Here ``t10`` sorts before ``t9``.
+
+    Parameters
+    ----------
+    values
+        The **distinct** values of a key column.
+
+    Returns
+    -------
+    ranks : NDArray[np.uint32]
+        ``ranks[i]`` is the sorted position of ``values[i]``.
+
+    Examples
+    --------
+    >>> lexical_rank(["chr10", "chr2", "chr1"])
+    array([1, 2, 0], dtype=uint32)
+    """
+    rust_mod = importlib.import_module(".ruranges", package="ruranges")
+    return rust_mod.lexical_rank_numpy(list(values))
+
+
+def fold_ranks(
+    group: NDArray[np.uint32],
+    group_cardinality: int,
+    codes: NDArray[np.uint32],
+    codes_cardinality: int,
+) -> tuple[NDArray[np.uint32], int]:
+    """
+    Fold one key column's codes into a running group id.
+
+    A multi-key sort codes each key column separately and then collapses all but
+    the last two into the single ``groups`` argument :func:`sort_intervals`
+    takes.  This is that collapse, one column at a time.
+
+    Parameters
+    ----------
+    group
+        Codes of every key folded so far, one per row.
+    group_cardinality
+        Number of distinct values in *group*.
+    codes
+        Codes of the next key, one per row.
+    codes_cardinality
+        Number of distinct values in *codes*.
+
+    Returns
+    -------
+    folded : NDArray[np.uint32]
+        Codes ordering rows by the old key first and the new key second.
+    cardinality : int
+        Number of distinct values in *folded*, to pass back in as
+        *group_cardinality* on the next fold.
+
+    Notes
+    -----
+    ``group * codes_cardinality + codes`` overflows ``uint32`` once the keys are
+    wide enough; when it would, the combined key is re-densified instead, which
+    preserves the order and caps cardinality at the row count.
+
+    Examples
+    --------
+    >>> folded, cardinality = fold_ranks(
+    ...     np.array([0, 0, 1, 1], dtype=np.uint32), 2,
+    ...     np.array([1, 0, 1, 0], dtype=np.uint32), 2,
+    ... )
+    >>> folded
+    array([1, 0, 3, 2], dtype=uint32)
+    >>> cardinality
+    4
+    """
+    rust_mod = importlib.import_module(".ruranges", package="ruranges")
+    return rust_mod.fold_ranks_numpy(
+        _normalize_groups(group, name="group"),
+        int(group_cardinality),
+        _normalize_groups(codes, name="codes"),
+        int(codes_cardinality),
+    )
+
 
 def sort_groups(
     groups: NDArray[GroupIdInt],

--- a/src/bindings/lib.rs
+++ b/src/bindings/lib.rs
@@ -25,6 +25,7 @@ use crate::numpy_bindings::max_disjoint_numpy::*;
 use crate::numpy_bindings::merge_numpy::*;
 use crate::numpy_bindings::nearest_numpy::*;
 use crate::numpy_bindings::overlaps_numpy::*;
+use crate::numpy_bindings::ranks_numpy::*;
 use crate::numpy_bindings::sort_intervals_numpy::*;
 use crate::numpy_bindings::spliced_subsequence_numpy::*;
 use crate::numpy_bindings::split_numpy::*;
@@ -72,6 +73,10 @@ fn ruranges(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(count_overlaps_numpy_u32_i32, m)?)?;
     m.add_function(wrap_pyfunction!(count_overlaps_numpy_u32_i64, m)?)?;
+
+    m.add_function(wrap_pyfunction!(natural_rank_numpy, m)?)?;
+    m.add_function(wrap_pyfunction!(lexical_rank_numpy, m)?)?;
+    m.add_function(wrap_pyfunction!(fold_ranks_numpy, m)?)?;
 
     m.add_function(wrap_pyfunction!(sort_intervals_numpy_u32_i32, m)?)?;
     m.add_function(wrap_pyfunction!(sort_intervals_numpy_u32_i64, m)?)?;

--- a/src/bindings/numpy_bindings/mod.rs
+++ b/src/bindings/numpy_bindings/mod.rs
@@ -11,6 +11,7 @@ pub mod max_disjoint_numpy;
 pub mod merge_numpy;
 pub mod nearest_numpy;
 pub mod overlaps_numpy;
+pub mod ranks_numpy;
 pub mod sort_intervals_numpy;
 pub mod spliced_subsequence_numpy;
 pub mod split_numpy;

--- a/src/bindings/numpy_bindings/ranks_numpy.rs
+++ b/src/bindings/numpy_bindings/ranks_numpy.rs
@@ -1,0 +1,58 @@
+use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1};
+use pyo3::pybacked::PyBackedStr;
+use pyo3::{pyfunction, Py, PyResult, Python};
+
+use ruranges_core::ranks;
+
+/// Borrow the UTF-8 buffer of every element without copying it.
+///
+/// `PyBackedStr` keeps the owning Python object alive and hands back a `&str`
+/// pointing into its buffer, so a column's distinct values cross the boundary
+/// once, as pointers, rather than being re-encoded into Rust `String`s.
+fn as_str_slice(values: &[PyBackedStr]) -> Vec<&str> {
+    values.iter().map(|value| &**value).collect()
+}
+
+macro_rules! define_rank_numpy {
+    ($fname:ident, $core:path, $doc:literal) => {
+        #[doc = $doc]
+        #[pyfunction]
+        #[pyo3(signature = (values))]
+        pub fn $fname(values: Vec<PyBackedStr>, py: Python<'_>) -> PyResult<Py<PyArray1<u32>>> {
+            let borrowed = as_str_slice(&values);
+            let ranks = py.detach(|| $core(&borrowed));
+            Ok(ranks.into_pyarray(py).to_owned().into())
+        }
+    };
+}
+
+define_rank_numpy!(
+    natural_rank_numpy,
+    ranks::natural_rank,
+    "Positions the values would occupy in natural order (`t2` before `t10`)."
+);
+define_rank_numpy!(
+    lexical_rank_numpy,
+    ranks::lexical_rank,
+    "Positions the values would occupy in byte-lexical order (`t10` before `t9`)."
+);
+
+/// Fold one key column's codes into a running group id.
+///
+/// Returns the folded ids and their cardinality, so the caller can fold again.
+#[pyfunction]
+#[pyo3(signature = (group, group_cardinality, codes, codes_cardinality))]
+pub fn fold_ranks_numpy(
+    group: PyReadonlyArray1<u32>,
+    group_cardinality: u32,
+    codes: PyReadonlyArray1<u32>,
+    codes_cardinality: u32,
+    py: Python<'_>,
+) -> PyResult<(Py<PyArray1<u32>>, u32)> {
+    let mut folded = group.as_slice()?.to_vec();
+    let codes = codes.as_slice()?;
+    let cardinality = py.detach(|| {
+        ranks::fold_ranks(&mut folded, group_cardinality, codes, codes_cardinality)
+    });
+    Ok((folded.into_pyarray(py).to_owned().into(), cardinality))
+}


### PR DESCRIPTION
## Summary

- Binds `natural_rank`, `lexical_rank` and `fold_ranks` from `ruranges-core::ranks` (0.1.12). Together with `sort_intervals` these are the whole of a multi-key interval sort: code each key column to an ascending integer, fold all but the innermost two into a group id, one kernel call, one gather. What stays on the caller's side is what genuinely depends on whether the frame is pandas or polars -- column resolution, numeric dtype coding, the final take.
- The ranking functions take the *distinct* values of a key column, not the rows, so their cost is per distinct value: 25 chromosome names are free however many rows there are. `PyBackedStr` borrows each Python string's UTF-8 buffer rather than copying it, and the sort runs with the GIL released. Handing 10 million distinct values across the boundary costs 0.16 s worst case (legacy `object`-dtype pandas columns; zero for pandas 3's arrow-backed `str`), against 24.9 s to natural-sort them in Python.
- **Breaking:** `sort_intervals` takes `groups` keyword-only now. All three of `starts`, `ends`, `groups` are same-length integer arrays, so a transposition is undetectable at runtime and produces a plausible-looking wrong answer rather than an error -- `pyranges1.RangeFrame.sort_ranges` shipped for two releases sorting by `End` before `Start` for exactly this reason, putting 97,964 of 100,000 rows in the wrong place on a realistic frame. The same mistake is now a `TypeError` at the first call.
- README gains a worked example (`sort_intervals` + `natural_rank`/`lexical_rank`/`fold_ranks` composed for a multi-key sort) and a cheat-sheet row for the new functions.
- `0.1.6 -> 0.1.7`.

## Test plan

- [x] `maturin develop --release`, then confirmed the bindings agree with Python's `natsort` 8.4.0 on 18,507 randomized realistic strings
- [x] Confirmed `sort_intervals(starts, ends, groups)` (old positional call) now raises `TypeError`
- [x] Rebuilt and smoke-tested against the published `ruranges-core` 0.1.12 (no path patch)
- [x] README example runs as written

Generated with Claude Code
