### PR TITLE
nearest takes ties="first"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,3 @@ ruranges-core = { version = "0.1.13" }
 rustc-hash = "2.1.0"
 pyo3 = { version = "0.26.0", optional = false }
 numpy = { version = "0.26.0", optional = true }
-
-# Development override: `nearest_with_ties` lands in ruranges-core 0.1.13.
-# Drop this patch once 0.1.13 is on crates.io.
-[patch.crates-io]
-ruranges-core = { path = "../ruranges-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruranges-py"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,9 +18,14 @@ python-module = ["pyo3/extension-module"]
 
 [dependencies]
 # Core interval algorithms now live in the separate Rust crate/repo.
-ruranges-core = { version = "0.1.12" }
+ruranges-core = { version = "0.1.13" }
 
 # Python bindings.
 rustc-hash = "2.1.0"
 pyo3 = { version = "0.26.0", optional = false }
 numpy = { version = "0.26.0", optional = true }
+
+# Development override: `nearest_with_ties` lands in ruranges-core 0.1.13.
+# Drop this patch once 0.1.13 is on crates.io.
+[patch.crates-io]
+ruranges-core = { path = "../ruranges-core" }

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ for a, b, d in zip(idx1, idx2, dist):
 
 Set direction to "forward" or "backward" to restrict to one side.
 
+Set `ties="first"` to report one neighbour per distance rather than every
+neighbour at that distance. It matters most with `include_overlaps=True`,
+where every interval a query overlaps is a neighbour at distance 0: on dense
+inputs that is the difference between one output row per query and one per
+overlapping pair.
+
 ---
 
 ## 3. subtract

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.maturin]
 module-name = "ruranges.ruranges"

--- a/ruranges/numpy.py
+++ b/ruranges/numpy.py
@@ -182,6 +182,7 @@ def nearest(
     include_overlaps: bool = True,
     direction: Literal["forward", "backward", "any"] = "any",
     sort_output: bool = True,
+    ties: Literal["all", "first"] = "all",
 ) -> tuple[NDArray[GroupIdInt], NDArray[GroupIdInt], NDArray[RangeInt]]:
     """
     Find the *k* nearest intervals from *(starts2, ends2)* for every interval
@@ -207,6 +208,14 @@ def nearest(
         • ``"forward"`` – only neighbours that start **after** the query ends
         • ``"backward"`` – only neighbours that end **before** the query starts
         • ``"any"`` (default) – both directions.
+    ties
+        How many neighbours to report when several sit at the same distance.
+        • ``"all"`` (default) – all of them, at each of the *k* distances.
+        • ``"first"`` – one of them per distance, so at most *k* rows per
+          query. Which one is unspecified, but the same input gives the same
+          answer every time. With ``include_overlaps`` this is the difference
+          between reporting every interval a query overlaps and reporting one,
+          which on dense inputs is orders of magnitude of output.
 
     Returns
     -------
@@ -218,8 +227,9 @@ def nearest(
     Raises
     ------
     ValueError
-        If the input lengths don’t match or only one of ``groups`` /
-        ``groups2`` is supplied.
+        If the input lengths don’t match, only one of ``groups`` /
+        ``groups2`` is supplied, or ``ties`` is neither ``"all"`` nor
+        ``"first"``.
     """
     return _dispatch_binary(
         "nearest_numpy",
@@ -234,6 +244,7 @@ def nearest(
         include_overlaps=include_overlaps,
         direction=direction,
         sort_output=sort_output,
+        ties=ties,
     )
 
 

--- a/src/bindings/numpy_bindings/nearest_numpy.rs
+++ b/src/bindings/numpy_bindings/nearest_numpy.rs
@@ -1,7 +1,18 @@
+use std::str::FromStr;
+
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1};
+use pyo3::exceptions::PyValueError;
 use pyo3::{pyfunction, Py, PyResult, Python};
 
-use ruranges_core::nearest::nearest;
+use ruranges_core::nearest::{nearest_with_ties, Ties};
+
+/// Parse `ties` here rather than letting the kernel's `FromStr` panic: a
+/// `PanicException` is not an `Exception`, so `except Exception` cannot catch
+/// it and the interpreter is aborted instead of the caller seeing an error.
+fn parse_ties(value: &str) -> PyResult<Ties> {
+    Ties::from_str(value)
+        .map_err(|_| PyValueError::new_err(format!("ties must be 'all' or 'first'; got {value:?}")))
+}
 
 macro_rules! define_nearest_numpy {
     ($fname:ident, $chr_ty:ty, $pos_ty:ty) => {
@@ -18,6 +29,7 @@ macro_rules! define_nearest_numpy {
             include_overlaps = true,
             direction = "any",
             sort_output = true,
+            ties = "all",
         ))]
         #[allow(non_snake_case)]
         pub fn $fname(
@@ -33,8 +45,9 @@ macro_rules! define_nearest_numpy {
             include_overlaps: bool,
             direction: &str,
             sort_output: bool,
+            ties: &str,
         ) -> PyResult<(Py<PyArray1<u32>>, Py<PyArray1<u32>>, Py<PyArray1<$pos_ty>>)> {
-            let (idx1, idx2, dist) = nearest(
+            let (idx1, idx2, dist) = nearest_with_ties(
                 chrs.as_slice()?,
                 starts.as_slice()?,
                 ends.as_slice()?,
@@ -46,6 +59,7 @@ macro_rules! define_nearest_numpy {
                 include_overlaps,
                 direction,
                 sort_output,
+                parse_ties(ties)?,
             );
 
             Ok((


### PR DESCRIPTION

**Repo** `pyranges/ruranges` · **base** `shared-string-ranker` · **head** `nearest-ties` · 5 files, +43 −7

## Why

`ruranges.numpy.nearest` reports every neighbour at the winning distance. With
`include_overlaps=True` every interval a query overlaps sits at distance 0, so on dense
inputs that is one output row per overlapping *pair* rather than per query: 1.1 billion rows
against 7.7 million on 100 million hg38-like intervals.

## What

```python
ruranges.numpy.nearest(..., ties="first")   # one neighbour per distance
ruranges.numpy.nearest(..., ties="all")     # default, unchanged
```

Binds `ruranges_core::nearest::nearest_with_ties`. The default path is the same kernel call
it always was.

`ties` is parsed in the binding rather than by the kernel's `FromStr`, which panics. A
`PanicException` is not an `Exception`, so `except Exception` cannot catch it and the
interpreter is aborted — the trap `direction` fell into, and that `pyranges1` had to add a
guard for. An unknown value raises `ValueError` naming the two options.

## Dependencies

Requires ruranges-core 0.1.13 (pyranges/ruranges-core#6). Until that is published the
manifest carries the same development override this repo used for 0.1.12, with a comment
saying to drop it on release.

Version: wheel 0.1.7 → 0.1.8, crate 0.2.5 → 0.2.6.

## Verification

Built with `maturin develop --release` and exercised end to end:

```
>>> nearest(..., ties="all")     idx1 [0, 0, 0, 1, 1, 1, 2]
>>> nearest(..., ties="first")   idx1 [0, 1, 2]
>>> nearest(..., ties="nope")    ValueError: ties must be 'all' or 'first'; got "nope"
```

The behaviour itself is tested in ruranges-core; the two libraries downstream of this
binding (`pyranges1` 1.4.3, `polaranges` 0.4.0) test the option through it, and
`polaranges`'s randomized oracle checks all three implementations against each other with
`ties` varying.
