### PR TITLE
Build stable-ABI wheels for Python 3.12+

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Build and test wheels
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
-          CIBW_BUILD: "cp312-* cp313-*"
+          # abi3-py312 produces one wheel per platform for CPython >= 3.12.
+          CIBW_BUILD: "cp312-*"
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
@@ -100,9 +101,35 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
+  abi3-compatibility:
+    name: ABI3 import (Python ${{ matrix.python-version }})
+    needs: wheels
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download Linux wheels
+        uses: actions/download-artifact@v8
+        with:
+          name: wheels-linux
+          path: dist
+
+      - name: Install and test the stable-ABI wheel
+        run: |
+          python -m pip install --upgrade pip numpy
+          python -m pip install --no-index --find-links dist ruranges
+          python -c "import numpy as np, ruranges.numpy as k; s=np.array([1,5],dtype=np.int64); e=np.array([4,9],dtype=np.int64); g=np.zeros(2,dtype=np.uint32); assert len(k.merge(starts=s,ends=e,groups=g,slack=0)[0])==2; print('ruranges ABI3 ok')"
+
   publish:
     name: Verify and publish
-    needs: [wheels, sdist]
+    needs: [wheels, sdist, abi3-compatibility]
     runs-on: ubuntu-latest
     steps:
       - name: Download distributions
@@ -122,28 +149,28 @@ jobs:
           wheels = [name for name in files if name.endswith(".whl")]
           sdists = [name for name in files if name.endswith(".tar.gz")]
 
-          assert len(files) == 9, f"expected 9 distributions, found {len(files)}: {files}"
-          assert len(wheels) == 8, f"expected 8 wheels, found {len(wheels)}: {wheels}"
+          assert len(files) == 5, f"expected 5 distributions, found {len(files)}: {files}"
+          assert len(wheels) == 4, f"expected 4 wheels, found {len(wheels)}: {wheels}"
           assert len(sdists) == 1, f"expected 1 sdist, found {len(sdists)}: {sdists}"
 
-          for python_tag in ("cp312-cp312", "cp313-cp313"):
-              expected_platforms = (
-                  "manylinux_2_28_x86_64",
-                  "manylinux_2_28_aarch64",
-              )
-              for platform_tag in expected_platforms:
-                  assert any(
-                      f"-{python_tag}-{platform_tag}.whl" in name for name in wheels
-                  ), f"missing {python_tag} {platform_tag} wheel: {wheels}"
+          python_tag = "cp312-abi3"
+          expected_platforms = (
+              "manylinux_2_28_x86_64",
+              "manylinux_2_28_aarch64",
+          )
+          for platform_tag in expected_platforms:
+              assert any(
+                  f"-{python_tag}-{platform_tag}.whl" in name for name in wheels
+              ), f"missing {python_tag} {platform_tag} wheel: {wheels}"
 
-              assert any(
-                  f"-{python_tag}-macosx_" in name and name.endswith("_x86_64.whl")
-                  for name in wheels
-              ), f"missing {python_tag} macOS x86_64 wheel: {wheels}"
-              assert any(
-                  f"-{python_tag}-macosx_" in name and name.endswith("_arm64.whl")
-                  for name in wheels
-              ), f"missing {python_tag} macOS arm64 wheel: {wheels}"
+          assert any(
+              f"-{python_tag}-macosx_" in name and name.endswith("_x86_64.whl")
+              for name in wheels
+          ), f"missing {python_tag} macOS x86_64 wheel: {wheels}"
+          assert any(
+              f"-{python_tag}-macosx_" in name and name.endswith("_arm64.whl")
+              for name in wheels
+          ), f"missing {python_tag} macOS arm64 wheel: {wheels}"
 
           print("Verified distribution set:")
           print("\n".join(files))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ ruranges-core = { version = "0.1.13" }
 
 # Python bindings.
 rustc-hash = "2.1.0"
-pyo3 = { version = "0.26.0", optional = false }
-numpy = { version = "0.26.0", optional = true }
+pyo3 = { version = "0.29.2", features = ["abi3-py312"], optional = false }
+numpy = { version = "0.29.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ pip install maturin
 maturin develop --release
 ```
 
+Release wheels use CPython's stable ABI with a Python 3.12 floor. One wheel per
+operating-system/architecture combination supports CPython 3.12 and newer,
+instead of publishing a separate wheel for every Python minor version.
+
 Quick check:
 ```bash
 python -c "import ruranges; print(ruranges.__version__)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ requires-python = ">=3.12"
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Rust",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",


### PR DESCRIPTION
## Summary

- upgrade PyO3 and numpy-rust to 0.29
- enable PyO3's `abi3-py312` stable ABI
- build one wheel per supported platform/architecture instead of one per Python minor version
- test the Linux x86_64 ABI3 wheel on Python 3.12, 3.13, and 3.14 before the publish job can run
- document the stable-ABI Python floor

## Context

This revisits the stable-ABI proposal from #24 against the current repository.
The package now requires Python 3.12, the core algorithms live in
`ruranges-core`, macOS wheels are built natively, and package versions are
already synchronized explicitly. Accordingly, this uses `abi3-py312`, retains
the current versioning scheme, and updates the current release workflow rather
than applying #24 verbatim.

This PR intentionally does not close #24 automatically; its discussion can be
wrapped up separately.

## Impact

The release set falls from eight wheels to four for the current two Python
versions and four platform/architecture combinations. The same four wheels
also cover Python 3.14 and future compatible CPython releases without adding a
new build per Python minor version.

Local matched-build testing found no meaningful performance or memory cost:

- 288 successful process benchmarks across all eight established operations,
  hg38 inputs from 1M through 100M, four implementations, and three repetitions
- ABI3/native geometric-mean runtime change: +0.11%
- ABI3/native geometric-mean peak-RSS change: -0.03%
- zero output-row parity mismatches
- median timing coefficient of variation: 0.73%, larger than the measured ABI difference

## Validation

- built `ruranges-0.2.7-cp312-abi3-macosx_11_0_arm64.whl` locally with maturin 1.14.1 and Rust 1.96.0
- imported and exercised the built ABI3 extension through PyRanges1 1.4.3
- ran the full local benchmark matrix described above
- parsed the updated workflow as YAML and checked the patch with `git diff --check`
